### PR TITLE
Added backtesting

### DIFF
--- a/src/core/backtest.py
+++ b/src/core/backtest.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from core.data_loader import load_tickers
+from core.data_loader import download_data
+from core.calc_spread import calculate_spread_and_thresholds
+from core.pair_selector import select_pairs
+
+def backtest_pair(price_a: pd.Series, price_b: pd.Series, entry_z: float = 2.0, exit_z: float = 0.0):
+    result = calculate_spread_and_thresholds(price_a, price_b)
+    zscore = result["zscore"]
+    spread = result["spread"]
+
+    position = 0  # 0 = no position, 1 = long spread, -1 = short spread
+    entry_price_a = entry_price_b = 0.0
+    trades = []
+    pnl = 0.0
+
+    for date in zscore.index:
+        z = zscore.loc[date]
+        pa = price_a.loc[date]
+        pb = price_b.loc[date]
+
+        if position == 0:
+            if z > entry_z:
+                # SHORT A, LONG B
+                position = -1
+                entry_price_a, entry_price_b = pa, pb
+            elif z < -entry_z:
+                # LONG A, SHORT B
+                position = 1
+                entry_price_a, entry_price_b = pa, pb
+
+        elif position == -1 and z < exit_z:
+            # Exit SHORT A, LONG B
+            trade_pnl = (entry_price_a - pa) + (pb - entry_price_b)
+            trades.append(trade_pnl)
+            pnl += trade_pnl
+            position = 0
+
+        elif position == 1 and z > exit_z:
+            # Exit LONG A, SHORT B
+            trade_pnl = (pa - entry_price_a) + (entry_price_b - pb)
+            trades.append(trade_pnl)
+            pnl += trade_pnl
+            position = 0
+
+    print(f"Total Trades: {len(trades)}")
+    print(f"Total PnL: {pnl:.2f}")
+    if trades:
+        print(f"Avg PnL per Trade: {pnl / len(trades):.2f}")
+        print(f"Win Rate: {sum(1 for t in trades if t > 0) / len(trades) * 100:.2f}%")
+
+if __name__ == "__main__":
+    tickers = load_tickers()
+    df = download_data(tickers, "2022-01-01", "2023-01-01")
+
+    selected_pairs = select_pairs(df["Adj Close"])
+
+    for pair in selected_pairs:
+        print(f"Backtesting pair: {pair[0]} and {pair[1]}")
+        price_a = df["Adj Close"][pair[0]]
+        price_b = df["Adj Close"][pair[1]]
+        backtest_pair(price_a, price_b)

--- a/src/core/calc_spread.py
+++ b/src/core/calc_spread.py
@@ -1,0 +1,45 @@
+# --- Spread and Threshold Calculation ---
+import pandas as pd
+import statsmodels.api as sm
+from typing import Dict, Any
+
+def calculate_spread_and_thresholds(price_a: pd.Series, price_b: pd.Series) -> Dict[str, Any]:
+    """
+    Calculate the spread between two price series using linear regression to determine the hedge ratio (beta),
+    and compute mean, standard deviation, and z-score thresholds for trading.
+
+    Args:
+        price_a (pd.Series): Price series of stock A.
+        price_b (pd.Series): Price series of stock B.
+
+    Returns:
+        dict: Dictionary containing spread, mean, std, zscore series, and thresholds.
+    """
+    # Step 1: Regress A on B to get hedge ratio (beta)
+    X = sm.add_constant(price_b)
+    model = sm.OLS(price_a, X).fit()
+    beta = model.params.iloc[1]
+
+    # Step 2: Calculate spread using hedge ratio
+    spread = price_a - beta * price_b
+
+    # Step 3: Compute mean and standard deviation of spread
+    mean = spread.mean()
+    std = spread.std()
+
+    # Step 4: Compute z-score to normalize spread
+    zscore = (spread - mean) / std  # type: ignore
+
+    # Step 5: Define default thresholds for trading signals
+    entry_threshold = 2.0
+    exit_threshold = 0.0
+
+    return {
+        "spread": spread,
+        "zscore": zscore,
+        "mean": mean,
+        "std": std,
+        "entry_threshold": entry_threshold,
+        "exit_threshold": exit_threshold,
+        "beta": beta
+    }

--- a/tests/test_calc_spread.py
+++ b/tests/test_calc_spread.py
@@ -1,0 +1,26 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import pandas as pd
+from core.data_loader import download_data
+from core.calc_spread import calculate_spread_and_thresholds
+
+def test_spread_calculation():
+    tickers = ['AAPL', 'MSFT']
+    start_date = '2022-01-01'
+    end_date = '2023-01-01'
+
+    # Load price data
+    df = download_data(tickers, start_date, end_date)
+    price_a = df['Adj Close']['AAPL']
+    price_b = df['Adj Close']['MSFT']
+
+    # Run spread calculation
+    result = calculate_spread_and_thresholds(price_a, price_b)
+
+    # Print results for inspection
+    print("Beta:", result['beta'])
+    print("Spread Mean:", result['mean'])
+    print("Spread Std:", result['std'])
+    print("Latest Z-score:", result['zscore'].iloc[-1])


### PR DESCRIPTION
 Added Backtesting Module

This pull request introduces a new backtest.py script and related components for performing historical evaluation of selected cointegrated stock pairs using a z-score based mean-reversion strategy.

Summary of Changes:
	•	Implemented backtest_pair() to simulate trade entries and exits based on z-score thresholds
	•	Integrated calculate_spread_and_thresholds() for dynamic spread and z-score calculation
	•	Added test_calc_spread.py to validate hedge ratio, spread, and z-score calculations using real market data
	•	Included support for reading tickers from file (tickers.txt) and selecting top pairs with high correlation and cointegration

Output Includes:
	•	Trade count
	•	Total and average PnL
	•	Win rate per pair

This sets the foundation for future enhancements like performance plotting, risk analysis, and live deployment.