### PR TITLE
Backtest module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup run test freeze clean
+.PHONY: setup run test freeze clean backtest
 
 PYTHON := .venv/bin/python
 PIP := .venv/bin/pip
@@ -16,6 +16,9 @@ test:
 	black .
 	ruff check . --fix
 	PYTHONPATH=src $(PYTHON) -m pytest tests/
+
+backtest:
+	PYTHONPATH=src $(PYTHON) src/core/backtest.py
 
 freeze:
 	$(PIP) freeze > requirements.txt

--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ make run
 
 ---
 
+## 🧪 Running Backtesting
+```bash
+make backtest
+```
+
+This will:
+
+* Load tickers from data/tickers.txt
+* Download historical stock data using yfinance
+* Select statistically cointegrated pairs
+* Simulate trades based on z-score thresholds
+* Output metrics like:
+   * Number of trades
+   * Total PnL
+   * Win rate		
+
+Make sure you have a valid tickers.txt file inside the data/ folder with one ticker per line.
+
+---
+
 ## 🧪 Running Tests
 
 ```bash

--- a/src/core/backtest.py
+++ b/src/core/backtest.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from core.data_loader import load_tickers
+from core.data_loader import download_data
+from core.calc_spread import calculate_spread_and_thresholds
+from core.pair_selector import select_pairs
+
+def backtest_pair(price_a: pd.Series, price_b: pd.Series, entry_z: float = 2.0, exit_z: float = 0.0):
+    result = calculate_spread_and_thresholds(price_a, price_b)
+    zscore = result["zscore"]
+    spread = result["spread"]
+
+    position = 0  # 0 = no position, 1 = long spread, -1 = short spread
+    entry_price_a = entry_price_b = 0.0
+    trades = []
+    pnl = 0.0
+
+    for date in zscore.index:
+        z = zscore.loc[date]
+        pa = price_a.loc[date]
+        pb = price_b.loc[date]
+
+        if position == 0:
+            if z > entry_z:
+                # SHORT A, LONG B
+                position = -1
+                entry_price_a, entry_price_b = pa, pb
+            elif z < -entry_z:
+                # LONG A, SHORT B
+                position = 1
+                entry_price_a, entry_price_b = pa, pb
+
+        elif position == -1 and z < exit_z:
+            # Exit SHORT A, LONG B
+            trade_pnl = (entry_price_a - pa) + (pb - entry_price_b)
+            trades.append(trade_pnl)
+            pnl += trade_pnl
+            position = 0
+
+        elif position == 1 and z > exit_z:
+            # Exit LONG A, SHORT B
+            trade_pnl = (pa - entry_price_a) + (entry_price_b - pb)
+            trades.append(trade_pnl)
+            pnl += trade_pnl
+            position = 0
+
+    print(f"Total Trades: {len(trades)}")
+    print(f"Total PnL: {pnl:.2f}")
+    if trades:
+        print(f"Avg PnL per Trade: {pnl / len(trades):.2f}")
+        print(f"Win Rate: {sum(1 for t in trades if t > 0) / len(trades) * 100:.2f}%")
+
+if __name__ == "__main__":
+    tickers = load_tickers()
+    df = download_data(tickers, "2022-01-01", "2023-01-01")
+
+    selected_pairs = select_pairs(df["Adj Close"])
+
+    for pair in selected_pairs:
+        print(f"Backtesting pair: {pair[0]} and {pair[1]}")
+        price_a = df["Adj Close"][pair[0]]
+        price_b = df["Adj Close"][pair[1]]
+        backtest_pair(price_a, price_b)

--- a/src/core/backtest.py
+++ b/src/core/backtest.py
@@ -4,10 +4,12 @@ from core.data_loader import download_data
 from core.calc_spread import calculate_spread_and_thresholds
 from core.pair_selector import select_pairs
 
-def backtest_pair(price_a: pd.Series, price_b: pd.Series, entry_z: float = 2.0, exit_z: float = 0.0):
+
+def backtest_pair(
+    price_a: pd.Series, price_b: pd.Series, entry_z: float = 2.0, exit_z: float = 0.0
+):
     result = calculate_spread_and_thresholds(price_a, price_b)
     zscore = result["zscore"]
-    spread = result["spread"]
 
     position = 0  # 0 = no position, 1 = long spread, -1 = short spread
     entry_price_a = entry_price_b = 0.0
@@ -48,6 +50,7 @@ def backtest_pair(price_a: pd.Series, price_b: pd.Series, entry_z: float = 2.0, 
     if trades:
         print(f"Avg PnL per Trade: {pnl / len(trades):.2f}")
         print(f"Win Rate: {sum(1 for t in trades if t > 0) / len(trades) * 100:.2f}%")
+
 
 if __name__ == "__main__":
     tickers = load_tickers()

--- a/src/core/calc_spread.py
+++ b/src/core/calc_spread.py
@@ -1,0 +1,45 @@
+# --- Spread and Threshold Calculation ---
+import pandas as pd
+import statsmodels.api as sm
+from typing import Dict, Any
+
+def calculate_spread_and_thresholds(price_a: pd.Series, price_b: pd.Series) -> Dict[str, Any]:
+    """
+    Calculate the spread between two price series using linear regression to determine the hedge ratio (beta),
+    and compute mean, standard deviation, and z-score thresholds for trading.
+
+    Args:
+        price_a (pd.Series): Price series of stock A.
+        price_b (pd.Series): Price series of stock B.
+
+    Returns:
+        dict: Dictionary containing spread, mean, std, zscore series, and thresholds.
+    """
+    # Step 1: Regress A on B to get hedge ratio (beta)
+    X = sm.add_constant(price_b)
+    model = sm.OLS(price_a, X).fit()
+    beta = model.params.iloc[1]
+
+    # Step 2: Calculate spread using hedge ratio
+    spread = price_a - beta * price_b
+
+    # Step 3: Compute mean and standard deviation of spread
+    mean = spread.mean()
+    std = spread.std()
+
+    # Step 4: Compute z-score to normalize spread
+    zscore = (spread - mean) / std  # type: ignore
+
+    # Step 5: Define default thresholds for trading signals
+    entry_threshold = 2.0
+    exit_threshold = 0.0
+
+    return {
+        "spread": spread,
+        "zscore": zscore,
+        "mean": mean,
+        "std": std,
+        "entry_threshold": entry_threshold,
+        "exit_threshold": exit_threshold,
+        "beta": beta
+    }

--- a/src/core/calc_spread.py
+++ b/src/core/calc_spread.py
@@ -7,6 +7,27 @@ from typing import Dict, Any
 def calculate_spread_and_thresholds(
     price_a: pd.Series, price_b: pd.Series
 ) -> Dict[str, Any]:
+    """
+    Calculate the spread and associated statistical thresholds between two price series.
+
+    This function performs a linear regression of `price_a` on `price_b` to compute the spread,
+    calculates its mean and standard deviation, and determines z-scores and thresholds for
+    entry and exit signals in a trading strategy.
+
+    Args:
+        price_a (pd.Series): The first price series (dependent variable).
+        price_b (pd.Series): The second price series (independent variable).
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the following keys:
+            - "spread" (pd.Series): The calculated spread.
+            - "zscore" (pd.Series): The z-scores of the spread.
+            - "mean" (float): The mean of the spread.
+            - "std" (float): The standard deviation of the spread.
+            - "entry_threshold" (float): The z-score threshold for entering a trade.
+            - "exit_threshold" (float): The z-score threshold for exiting a trade.
+            - "beta" (float): The regression coefficient (beta) of `price_b`.
+    """
     import pandas as pd
 
     # Combine series and drop NaNs

--- a/tests/test_calc_spread.py
+++ b/tests/test_calc_spread.py
@@ -1,0 +1,26 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import pandas as pd
+from core.data_loader import download_data
+from core.calc_spread import calculate_spread_and_thresholds
+
+def test_spread_calculation():
+    tickers = ['AAPL', 'MSFT']
+    start_date = '2022-01-01'
+    end_date = '2023-01-01'
+
+    # Load price data
+    df = download_data(tickers, start_date, end_date)
+    price_a = df['Adj Close']['AAPL']
+    price_b = df['Adj Close']['MSFT']
+
+    # Run spread calculation
+    result = calculate_spread_and_thresholds(price_a, price_b)
+
+    # Print results for inspection
+    print("Beta:", result['beta'])
+    print("Spread Mean:", result['mean'])
+    print("Spread Std:", result['std'])
+    print("Latest Z-score:", result['zscore'].iloc[-1])

--- a/tests/test_calc_spread.py
+++ b/tests/test_calc_spread.py
@@ -1,26 +1,27 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
-import pandas as pd
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
 from core.data_loader import download_data
 from core.calc_spread import calculate_spread_and_thresholds
 
+
 def test_spread_calculation():
-    tickers = ['AAPL', 'MSFT']
-    start_date = '2022-01-01'
-    end_date = '2023-01-01'
+    tickers = ["AAPL", "MSFT"]
+    start_date = "2022-01-01"
+    end_date = "2023-01-01"
 
     # Load price data
     df = download_data(tickers, start_date, end_date)
-    price_a = df['Adj Close']['AAPL']
-    price_b = df['Adj Close']['MSFT']
+    price_a = df["Adj Close"]["AAPL"]
+    price_b = df["Adj Close"]["MSFT"]
 
     # Run spread calculation
     result = calculate_spread_and_thresholds(price_a, price_b)
 
     # Print results for inspection
-    print("Beta:", result['beta'])
-    print("Spread Mean:", result['mean'])
-    print("Spread Std:", result['std'])
-    print("Latest Z-score:", result['zscore'].iloc[-1])
+    print("Beta:", result["beta"])
+    print("Spread Mean:", result["mean"])
+    print("Spread Std:", result["std"])
+    print("Latest Z-score:", result["zscore"].iloc[-1])


### PR DESCRIPTION
This PR introduces the initial implementation of the backtesting module for StatArbX. It enables simulated execution of pair trading strategies on historical data using Z-score-based signals.

⸻

Key Additions
	•	calc_spread.py: Computes spread, hedge ratio (beta), Z-score, and trading thresholds for a given stock pair.
	•	backtest.py: Runs a backtest on selected pairs with logic for position entry, exit, PnL tracking, and performance metrics.
	•	Integration of backtesting with load_tickers, download_data, and select_pairs.
	•	Unit test: test_calc_spread.py to validate spread and threshold calculations.
	•	Updated Makefile with make backtest command.
	•	Expanded README.md with backtesting instructions.

⸻

Next Steps
	•	Improve backtest logging and visualization.
	•	Add performance metrics like Sharpe ratio and drawdown.
	•	Prepare module for integration with live trading infra.
